### PR TITLE
Disable add/edit tags by user

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -53,7 +53,7 @@ Edits a student’s information such as n/NAME, p/PHONE_NUMBER.
 Edits a tuition class at specified t/TIME.
 
 #### Editing a student: `editstudent`
-Format: `editstudent INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…`
+Format: `editstudent INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS]`
 
 #### Editing a class: `editclass`
 Format: `editclass INDEX l/limit t/time n/NAME,NAME,NAME... [t/TAG]…`
@@ -114,7 +114,7 @@ Action | Format
 ***Add Class*** | `addclass l/limit t/time [s/NAME,NAME,NAME...] [r/REMARK] [t/TAG]…`
 ***View Student*** | `student [INDEX]`
 ***View Class*** | `class [INDEX]`
-***Edit Student*** | `editstudent [INDEX] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS]  [t/TAG]…`
+***Edit Student*** | `editstudent [INDEX] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS]`
 ***Edit Class*** | `editclass [INDEX] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…`
 ***Delete Student*** | `deletestudent [INDEX]`
 ***Delete Class*** | `deleteclass [INDEX]`

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -13,4 +13,5 @@ public class Messages {
     public static final String MESSAGE_STUDENT_NOT_FOUND = "This student is not found.";
     public static final String MESSAGE_CLASS_NOT_FOUND = "This tuition class is not found.";
     public static final String MESSAGE_STUDENT_NOT_IN_CLASS = "Student is not enrolled in this class.";
+    public static final String MESSAGE_INVALID_STUDENT_TAG = "Unable to add tags to students.";
 }

--- a/src/main/java/seedu/address/logic/commands/AddClassCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClassCommand.java
@@ -62,7 +62,7 @@ public class AddClassCommand extends Command {
         for (Person person: validStudentsAsPerson) {
             Person studentToChange = person;
             person.addClass(tuitionClass);
-            person.addTag(new Tag(tuitionClass.getName().getName() + " " + tuitionClass.getTimeslot().time));
+            person.addTag(new Tag(tuitionClass.getName().getName() + " | " + tuitionClass.getTimeslot().time));
             model.setPerson(studentToChange, person);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -24,14 +23,11 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 ";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/AddToClassCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddToClassCommand.java
@@ -27,10 +27,10 @@ public class AddToClassCommand extends Command {
             + PREFIX_TUITION_CLASS + "CLASS_INDEX"
             + "\n" + "Example1: " + COMMAND_WORD + " si/3 tc/3"
             + "\n" + "Example2: " + COMMAND_WORD + " s/Felicia,James tc/3";
-    public static final String MESSAGE_SUCCESS = "New student %1$s added to class.";
+    public static final String MESSAGE_SUCCESS = "New students: %1$s added to class";
     private static final String MESSAGE_STUDENT_EXISTS = "Student %1$s is already in the class";
     private static final String MESSAGE_CLASS_IS_FULL = "The following students are not "
-            + "added due to class limit: ";
+            + "added due to class limit";
     private static final String MESSAGE_STUDENT_NOT_FOUND = "The following students are not "
             + "found in the address book: ";
     private static final String MESSAGE_NO_STUDENT_ADDED = "No student has been added.";
@@ -147,7 +147,7 @@ public class AddToClassCommand extends Command {
             Person studentToAdd = person;
             Person studentToChange = person;
             studentToAdd.addClass(modifiedClass);
-            studentToAdd.addTag(new Tag(modifiedClass.getName().getName() + " "
+            studentToAdd.addTag(new Tag(modifiedClass.getName().getName() + " | "
                     + modifiedClass.getTimeslot().time));
             updateModel(model, tuitionClass, modifiedClass, studentToAdd, studentToChange);
         }
@@ -169,7 +169,7 @@ public class AddToClassCommand extends Command {
         }
         studentToAdd.addClass(modifiedClass);
         studentToAdd.addTag(new Tag(modifiedClass.getName().getName()
-                + " " + modifiedClass.getTimeslot().time));
+                + " | " + modifiedClass.getTimeslot().time));
         updateModel(model, tuitionClass, modifiedClass, studentToAdd, studentToChange);
         return new CommandResult(String.format(MESSAGE_SUCCESS, studentToAdd.getName().fullName, modifiedClass));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
@@ -45,7 +44,6 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -102,12 +100,12 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
-        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        //Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Remark updatedRemark = personToEdit.getRemark(); // edit command does not allow editing remarks
         Classes updateClasses = personToEdit.getClasses();
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress,
-                updatedRemark, updatedTags, updateClasses);
+                updatedRemark, personToEdit.getTags(), updateClasses);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/RemoveStudentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemoveStudentCommand.java
@@ -19,7 +19,7 @@ public class RemoveStudentCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Removes a student from a tuition class.\n"
-            + "Parameters: " + PREFIX_STUDENT_INDEX + "STUDENT_INDEX "
+            + "Parameters: " + PREFIX_STUDENT_INDEX + "STUDENT_INDEX " + "STUDENT_INDEX "
             + PREFIX_TUITION_CLASS + "CLASS_INDEX\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_STUDENT_INDEX + "1 2 " + PREFIX_TUITION_CLASS + "2";
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_STUDENT_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -9,7 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.ArrayList;
-import java.util.Set;
+import java.util.HashSet;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
@@ -21,7 +22,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Remark;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AddCommand object
@@ -38,6 +38,9 @@ public class AddCommandParser implements Parser<AddCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_REMARK, PREFIX_TAG);
 
+        if (arePrefixesPresent(argMultimap, PREFIX_TAG)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_STUDENT_TAG));
+        }
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
@@ -47,11 +50,11 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        //Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         Remark remark = ParserUtil.parseRemark(argMultimap.getOptionalValue(PREFIX_REMARK).get());
         Classes classes = new Classes(new ArrayList<Integer>());
 
-        Person person = new Person(name, phone, email, address, remark, tagList, classes);
+        Person person = new Person(name, phone, email, address, remark, new HashSet<>(), classes);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_STUDENT_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -43,6 +44,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            throw new ParseException(MESSAGE_INVALID_STUDENT_TAG);
+        }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }
@@ -55,7 +59,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
-        parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        //parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -100,7 +100,7 @@ public class Person {
         for (Integer id : classes.getClasses()) {
             if ((tuitionClass.getId()) == id) {
                 classes.removeClass(id);
-                removeTag(new Tag(tuitionClass.getName().getName()));
+                removeTag(new Tag(tuitionClass.getName().getName() + " | " + tuitionClass.getTimeslot().time));
                 return this;
             }
         }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -42,22 +42,23 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), EMPTY_REMARK,
-                getTagSet("friends", "Physics", "Chemistry"), new Classes(SAMPLE_CLASSES)),
+                getTagSet("Physics | Mon 10:00-12:00", "Chemistry | Tue 10:00-12:00"),
+                    new Classes(SAMPLE_CLASSES)),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), EMPTY_REMARK,
-                getTagSet("colleagues", "friends"), getEmptyClasses()),
+                getTagSet(), getEmptyClasses()),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), EMPTY_REMARK,
-                getTagSet("neighbours"), getEmptyClasses()),
+                getTagSet(), getEmptyClasses()),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), EMPTY_REMARK,
-                getTagSet("family"), getEmptyClasses()),
+                getTagSet(), getEmptyClasses()),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), EMPTY_REMARK,
-                getTagSet("classmates"), getEmptyClasses()),
+                getTagSet(), getEmptyClasses()),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), EMPTY_REMARK,
-                getTagSet("colleagues"), getEmptyClasses())
+                getTagSet(), getEmptyClasses())
         };
     }
 


### PR DESCRIPTION
Prevents users from adding/editing tags for students.
Also resolves the bug of overwriting tags for classes of the same name at different times.