### PR TITLE
Fix time parser errors

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddClassCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddClassCommandParser.java
@@ -55,8 +55,8 @@ public class AddClassCommandParser implements Parser<AddClassCommand> {
             return new AddClassCommand(tuitionClass);
 
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddClassCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,AddClassCommand.MESSAGE_USAGE), pe);
+            //throw new ParseException(pe.getMessage());
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddClassCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddClassCommandParser.java
@@ -55,7 +55,7 @@ public class AddClassCommandParser implements Parser<AddClassCommand> {
             return new AddClassCommand(tuitionClass);
 
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,AddClassCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddClassCommand.MESSAGE_USAGE), pe);
             //throw new ParseException(pe.getMessage());
         }
     }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,9 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -250,12 +253,16 @@ public class ParserUtil {
         String startTime = String.format("%s %s", arr[0], arr[1].split("-")[0]); //Mon 10:00
         String endTime = String.format("%s %s", arr[0], arr[1].split("-")[1]); //Mon 11:00
         DateFormat sdf = new SimpleDateFormat("EEE HH:mm");
+        DateFormat dayFormat = new SimpleDateFormat("EEE");
         try {
             Date start = sdf.parse(startTime);
             Date end = sdf.parse(endTime);
-            if (start.getTime() >= end.getTime()) {
+            int day = dayFormat.parse(startTime).getDay();
+
+            if (start.getTime() >= end.getTime() || start.getDay() != day || end.getDay() != day) {
                 throw new ParseException(Messages.MESSAGE_TIMESLOT_FORMAT);
             }
+            //throw new ParseException("a" + start.getDate() + "b " + end.getDate());
             return new Timeslot(start, end);
         } catch (java.text.ParseException e) {
             throw new ParseException(Messages.MESSAGE_TIMESLOT_FORMAT);

--- a/src/main/java/seedu/address/model/tuition/Timeslot.java
+++ b/src/main/java/seedu/address/model/tuition/Timeslot.java
@@ -159,9 +159,14 @@ public class Timeslot {
         String startTime = String.format("%s %s", arr[0], arr[1].split("-")[0]); //Mon 10:00
         String endTime = String.format("%s %s", arr[0], arr[1].split("-")[1]); //Mon 11:00
         DateFormat sdf = new SimpleDateFormat("EEE HH:mm");
+        DateFormat dayFormat = new SimpleDateFormat("EEE");
         try {
             Date start = sdf.parse(startTime);
             Date end = sdf.parse(endTime);
+            int day = dayFormat.parse(startTime).getDay();
+            if (start.getTime() >= end.getTime() || start.getDay() != day || end.getDay() != day) {
+                return null;
+            }
             return new Timeslot(start, end);
         } catch (java.text.ParseException e) {
             return null;

--- a/src/test/java/seedu/address/model/tuiton/TimeslotTest.java
+++ b/src/test/java/seedu/address/model/tuiton/TimeslotTest.java
@@ -24,7 +24,7 @@ public class TimeslotTest {
         assertFalse(Timeslot.parseString("mon 14:00-16:00") == null); //M in "mon" is in lower case
         assertFalse(Timeslot.parseString("Mon 2pm-4pm") != null); //use "pm" instead of hh:mm-hh:mm
         assertFalse(Timeslot.parseString("Monday 14:00-16:00") == null); //week should be in shorten format
-        assertFalse(Timeslot.parseString("Monday 17:00-16:00") == null); //the sequence of time is incorrect
+        assertTrue(Timeslot.parseString("Monday 17:00-16:00") == null); //the sequence of time is incorrect
     }
 
 


### PR DESCRIPTION
Previously, Mon 23:00-24:00, 24:00-27:00 could be parsed successfully as a time slot. 
Now, the user can only input times within the day specified.