### PR TITLE
Update CI badge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,7 @@ layout: page
 title: TutAssistor
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![CI Status](https://github.com/AY2122S1-CS2103T-T12-4/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2122S1-CS2103T-T12-4/tp/actions)
 [![codecov](https://codecov.io/gh/AY2122S1-CS2103T-T12-4/tp/branch/master/graph/badge.svg?token=EDWM7KCEX4)](https://codecov.io/gh/AY2122S1-CS2103T-T12-4/tp)
 
 ![Ui](images/Ui.png)


### PR DESCRIPTION
Previously the CI badge belongs to AB3 instead of TutAssistor.